### PR TITLE
fix: Restore support for disjoint caret assertions on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+
+- unit: Restore support for multiple disjoint caret assertions on one line, e.g. `^^  ^^^ source.xy`
+
 ## 0.6.0
 _2026-03-12_
 

--- a/src/unit/parser.ts
+++ b/src/unit/parser.ts
@@ -96,12 +96,12 @@ export function parse_file(str: string): Result<GrammarTestFile, Error> {
 
 		// Scope assertion line
 		if (is_assertion(line)) {
-			const assertion = assert_parser.parse_line(line)
-			if (assertion.error) {
-				return err(assertion.error)
+			const assertions = assert_parser.parse_line_assertions(line)
+			if (assertions.error) {
+				return err(assertions.error)
 			}
 
-			scope_assertions.push(assertion.value)
+			scope_assertions.push(...assertions.value)
 			continue
 		}
 
@@ -134,6 +134,15 @@ export class AssertionParser {
 	constructor(private readonly comment_length: number) {}
 
 	parse_line(line: string): Result<ScopeAssertion, SyntaxError> {
+		const assertions = this.parse_line_assertions(line)
+		if (assertions.error) {
+			return err(assertions.error)
+		}
+
+		return ok(assertions.value[0])
+	}
+
+	parse_line_assertions(line: string): Result<ScopeAssertion[], SyntaxError> {
 		let pos = 0
 
 		// Skip comment token and whitespace around
@@ -141,19 +150,34 @@ export class AssertionParser {
 		pos += this.comment_length
 		pos = this.skip_whitespace(line, pos)
 
-		const rangeResult = this.parse_assertion_range(line, pos)
-		if (rangeResult.error) {
-			return err(rangeResult.error)
+		let ranges: Array<{ from: number; to: number }> = []
+		let nextPos = pos
+
+		if (line[pos] === '^') {
+			const caretRanges = this.parse_caret_assertion_ranges(line, pos)
+			if (caretRanges.error) {
+				return err(caretRanges.error)
+			}
+
+			ranges = caretRanges.value.ranges
+			nextPos = caretRanges.value.nextPos
+		} else {
+			const rangeResult = this.parse_assertion_range(line, pos)
+			if (rangeResult.error) {
+				return err(rangeResult.error)
+			}
+
+			ranges = [{ from: rangeResult.value.from, to: rangeResult.value.to }]
+			nextPos = rangeResult.value.nextPos
 		}
 
-		const { from, to, nextPos } = rangeResult.value
 		const { scopes, excludes } = this.parse_scopes_and_exclusions(line.slice(nextPos))
 
 		if (scopes.length === 0 && excludes.length === 0) {
 			return err(new SyntaxError(ERR_ASSERT_NO_SCOPES))
 		}
 
-		return ok({ from, to, scopes, excludes })
+		return ok(ranges.map(({ from, to }) => ({ from, to, scopes, excludes })))
 	}
 
 	private skip_whitespace(line: string, pos: number): number {
@@ -200,6 +224,30 @@ export class AssertionParser {
 		}
 
 		return err(new SyntaxError(ERR_ASSERT_PARSE))
+	}
+
+	private parse_caret_assertion_ranges(
+		line: string,
+		pos: number,
+	): Result<{ ranges: Array<{ from: number; to: number }>; nextPos: number }, SyntaxError> {
+		const ranges: Array<{ from: number; to: number }> = []
+		let current = pos
+
+		while (line[current] === '^') {
+			const rangeResult = this.parse_assertion_range(line, current)
+			if (rangeResult.error) {
+				return err(rangeResult.error)
+			}
+
+			ranges.push({
+				from: rangeResult.value.from,
+				to: rangeResult.value.to,
+			})
+
+			current = this.skip_whitespace(line, rangeResult.value.nextPos)
+		}
+
+		return ok({ ranges, nextPos: current })
 	}
 
 	/**

--- a/src/unit/parser.ts
+++ b/src/unit/parser.ts
@@ -244,7 +244,12 @@ export class AssertionParser {
 				to: rangeResult.value.to,
 			})
 
-			current = this.skip_whitespace(line, rangeResult.value.nextPos)
+			const nextRangePos = this.skip_whitespace(line, rangeResult.value.nextPos)
+			if (line[nextRangePos] !== '^') {
+				return ok({ ranges, nextPos: rangeResult.value.nextPos })
+			}
+
+			current = nextRangePos
 		}
 
 		return ok({ ranges, nextPos: current })

--- a/test/unit/parser.test.ts
+++ b/test/unit/parser.test.ts
@@ -160,6 +160,23 @@ describe('AssertionParser multiple assertions in one line', () => {
 			},
 		])
 	})
+
+	test('reuses negative-only assertions for repeated caret groups', () => {
+		expect(unwrap(assert_parser.parse_line_assertions('# ^^^ ^^ ! source.xy'))).toStrictEqual([
+			{
+				from: 2,
+				to: 5,
+				scopes: [],
+				excludes: ['source.xy'],
+			},
+			{
+				from: 6,
+				to: 8,
+				scopes: [],
+				excludes: ['source.xy'],
+			},
+		])
+	})
 })
 
 describe('AssertionParser scopes', () => {
@@ -187,6 +204,12 @@ describe('AssertionParser scopes', () => {
 		)
 		expect(res.excludes).toHaveLength(2)
 		expect(res.scopes).toHaveLength(0)
+	})
+
+	test('caret exclusions', () => {
+		const res = unwrap(assert_parser.parse_line('# ^ ! source.xy'))
+		expect(res.scopes).toEqual([])
+		expect(res.excludes).toEqual(['source.xy'])
 	})
 
 	test('complex', () => {

--- a/test/unit/parser.test.ts
+++ b/test/unit/parser.test.ts
@@ -43,6 +43,25 @@ describe('parseTestFile', () => {
 		check_result(res)
 	})
 
+	test('multiple assertions in one line', () => {
+		const res = unwrap(parse_file('# SYNTAX TEST "source.xy"\nfoo bar\n# ^^  ^^^ source.xy\n'))
+		expect(res.test_lines).toHaveLength(1)
+		expect(res.test_lines[0]?.scope_asserts).toStrictEqual([
+			{
+				from: 2,
+				to: 4,
+				scopes: ['source.xy'],
+				excludes: [],
+			},
+			{
+				from: 6,
+				to: 9,
+				scopes: ['source.xy'],
+				excludes: [],
+			},
+		])
+	})
+
 	function check_result(res: GrammarTestFile) {
 		expect(res.metadata.scope).toBe('source.xy')
 		expect(res.metadata.comment_token).toBe('#')
@@ -100,6 +119,46 @@ describe('AssertionParser assert kinds', () => {
 		expect(res.scopes).toEqual(['source.xy'])
 		expect(res.from).toBe(6)
 		expect(res.to).toBe(9)
+	})
+})
+
+describe('AssertionParser multiple assertions in one line', () => {
+	const assert_parser = new AssertionParser(1)
+
+	test('reuses the same scopes for repeated caret groups', () => {
+		expect(unwrap(assert_parser.parse_line_assertions('# ^^  ^^^ source.xy'))).toStrictEqual([
+			{
+				from: 2,
+				to: 4,
+				scopes: ['source.xy'],
+				excludes: [],
+			},
+			{
+				from: 6,
+				to: 9,
+				scopes: ['source.xy'],
+				excludes: [],
+			},
+		])
+	})
+
+	test('reuses exclusions for repeated caret groups', () => {
+		expect(
+			unwrap(assert_parser.parse_line_assertions('# ^^  ^^^ source.xy ! foo.bar')),
+		).toStrictEqual([
+			{
+				from: 2,
+				to: 4,
+				scopes: ['source.xy'],
+				excludes: ['foo.bar'],
+			},
+			{
+				from: 6,
+				to: 9,
+				scopes: ['source.xy'],
+				excludes: ['foo.bar'],
+			},
+		])
 	})
 })
 


### PR DESCRIPTION
Restores support for multiple disjoint caret assertions on a single line, for example `^^  ^^^ source.xy`.

Previously, this shorthand was silently misparsed. For `# ^^  ^^^ source.xy`, the parser produced a single assertion with scopes `["^^^", "source.xy"]` instead of two separate caret assertions. This change parses each caret group as its own assertion, keeps the shared scope and exclusion tail, and adds regression tests.